### PR TITLE
Permite null em Payment Model $releaseDate

### DIFF
--- a/src/Lib/Model/Payment.php
+++ b/src/Lib/Model/Payment.php
@@ -14,7 +14,7 @@ class Payment
 
     public string $date;
 
-    public string $releaseDate;
+    public ?string $releaseDate;
 
     public float $amount;
 


### PR DESCRIPTION
Quando existe uma falha no pagamento por um motivo qualquer usando cartão de credito o campo releaseDate vem nulo da api.

![Screenshot_20](https://user-images.githubusercontent.com/3722700/94920691-26a24280-048d-11eb-812a-a915023c2a56.png)
