### PR TITLE
fix: split model attributes

### DIFF
--- a/src/Lib/Model/Split.php
+++ b/src/Lib/Model/Split.php
@@ -11,8 +11,8 @@ class Split
     /** @var string|null $recipientToken defines the recipient of the split */
     public ?string $recipientToken;
 
-    /** @var int|null $amount defines the fixed value that the account will receive */
-    public ?int $amount;
+    /** @var float|null $amount defines the fixed value that the account will receive */
+    public ?float $amount;
 
     /** @var float|null $percentage defines the percentage of the value that the account will receive */
     public ?float $percentage;

--- a/src/Lib/Model/Split.php
+++ b/src/Lib/Model/Split.php
@@ -9,19 +9,19 @@ class Split
     use Serializable;
 
     /** @var string|null $recipientToken defines the recipient of the split */
-    private ?string $recipientToken;
+    public ?string $recipientToken;
 
     /** @var int|null $amount defines the fixed value that the account will receive */
-    private ?int $amount;
+    public ?int $amount;
 
     /** @var float|null $percentage defines the percentage of the value that the account will receive */
-    private ?float $percentage;
+    public ?float $percentage;
 
     /** @var bool|null $amountReminder indicates who receives the remaining amount in the case of a division of the
      * total transaction amount */
-    private ?bool $amountReminder;
+    public ?bool $amountReminder;
 
     /** @var bool|null $chargeFee indicates whether only one recipient will be taxed or if the fees will be split
      * proportionally between all recipients */
-    private ?bool $chargeFee;
+    public ?bool $chargeFee;
 }


### PR DESCRIPTION
Todos os atributos do model Split foram definidos como privados, tornando impossível modifica-los e criar uma cobrança com split de pagamentos.

![Captura de tela de 2020-10-07 23-08-29](https://user-images.githubusercontent.com/21023685/95407248-db57bc00-08f2-11eb-9cae-08beef0463ed.png)

Além disso, o tipo do atributo amount está divergente do que foi definido na documentação

![Captura de tela de 2020-10-07 23-31-46](https://user-images.githubusercontent.com/21023685/95408364-a8fb8e00-08f5-11eb-8a0b-d25df636c34c.png)

