### PR TITLE
Re-add the field linesOfBusiness

### DIFF
--- a/src/Lib/Http/Account/AccountCreationRequest.php
+++ b/src/Lib/Http/Account/AccountCreationRequest.php
@@ -61,6 +61,9 @@ class AccountCreationRequest extends AccountRequest
 
     public string $type = self::PAYMENT_ACCOUNT_TYPE;
 
+    /** @var string $linesOfBusiness [0 .. 100 chars] free description */
+    public string $linesOfBusiness;
+
     // the bool default values are specified in Juno's documentation
     // all bool options defined below are marked as ADVANCED and should require additional permissions
 


### PR DESCRIPTION
Parece que eles não conseguem decidir que campos a API vai ter e são alterados sem aviso ou versionamento. Acho que o mais seguro para o futuro é não remover nenhum campo.