### PR TITLE
Adiciona nova constante para evento de pagamento e define as propriedades de Address para nullable

### DIFF
--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -9,11 +9,11 @@ class Address
 {
     use Serializable;
 
-    /** @var string $street Rua. */
-    protected string $street;
+    /** @var string|null $street Rua. */
+    protected ?string $street;
 
-    /** @var string $number Número. Se não houver, envie N/A. */
-    protected string $number;
+    /** @var string|null $number Número. Se não houver, envie N/A. */
+    protected ?string $number;
 
     /** @var string|null $complement Complemento. */
     protected ?string $complement = null;
@@ -21,27 +21,27 @@ class Address
     /** @var string|null $neighborhood Bairro. */
     protected ?string $neighborhood = null;
 
-    /** @var string $city Cidade. */
-    protected string $city;
+    /** @var string|null $city Cidade. */
+    protected ?string $city;
 
-    /** @var string $state Estado em sigla de Unidade Federativa (UF). */
-    protected string $state;
+    /** @var string|null $state Estado em sigla de Unidade Federativa (UF). */
+    protected ?string $state;
 
-    /** @var string $postCode Código de Endereçamento Postal no Brasil (CEP). */
-    protected string $postCode;
+    /** @var string|null $postCode Código de Endereçamento Postal no Brasil (CEP). */
+    protected ?string $postCode;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getStreet(): string
+    public function getStreet(): ?string
     {
         return $this->street;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getNumber(): string
+    public function getNumber(): ?string
     {
         return $this->number;
     }
@@ -63,25 +63,25 @@ class Address
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->state;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPostCode(): string
+    public function getPostCode(): ?string
     {
         return $this->postCode;
     }

--- a/src/Entity/Notification/PaymentData.php
+++ b/src/Entity/Notification/PaymentData.php
@@ -9,6 +9,15 @@ class PaymentData
     use Serializable;
     use EntityBaseTrait;
 
+    public const BANK_PAID_BACK = 'BANK_PAID_BACK';
+    public const PRE_CONFIRMED = 'PRECONFIRMED';
+    public const CONFIRMED = 'CONFIRMED';
+    public const PARTIALLY_REFUNDED = 'PARTIALLY_REFUNDED';
+    public const CUSTOMER_PAID_BACK = 'CUSTOMER_PAID_BACK';
+    public const DECLINED = 'DECLINED';
+    public const FAILED = 'FAILED';
+    public const NOT_AUTHORIZED = 'NOT_AUTHORIZED';
+
     protected PaymentAttributes $attributes;
 
     /**


### PR DESCRIPTION
O motivo de deixar nullable e adicionar uma nova constante é que está sendo enviado pela juno eventos com o status PRECONFIRMED, e o payload vem completo, mesmo que o payer não seja uma pessoa cadastrada na juno, e como não possui o cadastro a única informação que vem é o nome e documento, e o objeto de address inteiro com todos campos igual a null.