### PR TITLE
fix!: corrige entidade billing

### DIFF
--- a/src/Api/Payment/PaymentApi.php
+++ b/src/Api/Payment/PaymentApi.php
@@ -5,8 +5,8 @@ namespace Jetimob\Juno\Api\Payment;
 use GuzzleHttp\RequestOptions;
 use Jetimob\Http\Response;
 use Jetimob\Juno\Api\AbstractApi;
-use Jetimob\Juno\Entity\Billing;
 use Jetimob\Juno\Entity\CreditCardDetails;
+use Jetimob\Juno\Entity\PaymentBilling;
 use Throwable;
 
 /**
@@ -61,13 +61,13 @@ class PaymentApi extends AbstractApi
      * @link https://dev.juno.com.br/api/v2#operation/createPayment
      *
      * @param string $chargeId
-     * @param Billing $billing
+     * @param PaymentBilling $billing
      * @param CreditCardDetails $creditCardDetails
      *
      * @return Response
      * @throws Throwable
      */
-    public function createPayment(string $chargeId, Billing $billing, CreditCardDetails $creditCardDetails): Response
+    public function createPayment(string $chargeId, PaymentBilling $billing, CreditCardDetails $creditCardDetails): Response
     {
         return $this->mappedPost('payments', CreatePaymentResponse::class, [
             RequestOptions::JSON => [

--- a/src/Entity/Billing.php
+++ b/src/Entity/Billing.php
@@ -33,14 +33,6 @@ class Billing implements \JsonSerializable
     protected bool $notify = false;
 
     /**
-     * Pagamento realizados com cartão de crédito podem utilizar a funcionalidade de captura tardia. A captura tardia
-     * consiste apenas na autorização de um pagamento sem a sua efetivação, o valor autorizado fica retido no limite
-     * do cartão de crédito do pagador até a captura ou cancelamento.
-     * @var bool $delayed
-     */
-    protected bool $delayed = false;
-
-    /**
      * @return string
      */
     public function getName(): string
@@ -181,25 +173,6 @@ class Billing implements \JsonSerializable
     public function setNotify(bool $notify): Billing
     {
         $this->notify = $notify;
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isDelayed(): bool
-    {
-        return $this->delayed;
-    }
-
-    /**
-     * @param bool $delayed
-     *
-     * @return Billing
-     */
-    public function setDelayed(bool $delayed): Billing
-    {
-        $this->delayed = $delayed;
         return $this;
     }
 

--- a/src/Entity/PaymentBilling.php
+++ b/src/Entity/PaymentBilling.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jetimob\Juno\Entity;
+
+class PaymentBilling extends Billing
+{
+    /**
+     * Pagamento realizados com cartão de crédito podem utilizar a funcionalidade de captura tardia. A captura tardia
+     * consiste apenas na autorização de um pagamento sem a sua efetivação, o valor autorizado fica retido no limite
+     * do cartão de crédito do pagador até a captura ou cancelamento.
+     * @var bool $delayed
+     */
+    protected bool $delayed = false;
+
+    /**
+     * @return bool
+     */
+    public function isDelayed(): bool
+    {
+        return $this->delayed;
+    }
+
+    /**
+     * @param bool $delayed
+     *
+     * @return Billing
+     */
+    public function setDelayed(bool $delayed): Billing
+    {
+        $this->delayed = $delayed;
+        return $this;
+    }
+}


### PR DESCRIPTION
- adiciona especiaização de billing para pagamentos com cartão de crédito

Ao adicionar a propriedade `delayed` ao objeto billing, gerou o seguinte erro ao criar uma cobrança:

```
"$chargeResponse": [
    {
        "*message": "A propriedade delayed não faz parte do JSON esperado",
        "*errorCode": "351003",
        "*field": null,
        "*hydrationData": {
            "message": "A propriedade delayed não faz parte do JSON esperado",
            "errorCode": "351003"
        }
    }
],